### PR TITLE
Update find_all_contacts function to sort favorited contacts to the top

### DIFF
--- a/private/query_functions.php
+++ b/private/query_functions.php
@@ -316,23 +316,31 @@
 
 
     // Contacts
-    function find_all_contacts($sort='id') {
-        global $db;
+function find_all_contacts($sort='id') {
+    global $db;
 
-        // Define a whitelist of sortable columns
-        $valid_sort_columns = ['id', 'first_name', 'last_name', 'email'];
-        // Ensure the provided sort parameter is in the whitelist
-        if (!in_array($sort, $valid_sort_columns)) {
-            $sort = 'id'; // Default to 'id' if an invalid sort parameter is provided
-        }
-
-        $sql = "SELECT * FROM contact_list ";
-        $sql .= "ORDER BY " . $sort . " ASC"; // Append the valid sort parameter
-        //echo $sql;
-        $result = mysqli_query($db, $sql);
-        confirm_result_set($result);
-        return $result;
+    // Define a whitelist of sortable columns
+    $valid_sort_columns = ['id', 'first_name', 'last_name', 'email', 'favorite'];
+    // Ensure the provided sort parameter is in the whitelist
+    if (!in_array($sort, $valid_sort_columns)) {
+        $sort = 'id'; // Default to 'id' if an invalid sort parameter is provided
     }
+
+    $sql = "SELECT * FROM contact_list ";
+    // Check if the sort parameter is 'favorite', then sort DESC, otherwise sort ASC
+    if ($sort == 'favorite') {
+        $sql .= "ORDER BY " . $sort . " DESC"; // Favorited contacts will appear at the top
+    } else {
+        $sql .= "ORDER BY " . $sort . " ASC"; // Ascending order for other columns
+    }
+
+    // echo $sql; // For debugging
+
+    // Execute the SQL query
+    $result = mysqli_query($db, $sql);
+    confirm_result_set($result); // Check the result set
+    return $result;
+}
 
 
 function find_contact_by_id($id) {
@@ -403,9 +411,7 @@ function find_contact_by_id($id) {
     function update_contact($contact) {
         global $db;
 
-
         $rank_id = empty($contact['rank_id']) ? 'NULL' : db_escape($db, $contact['rank_id']); // Handle empty rank_id
-
 
         $errors = validate_contact($contact);
         if (!empty($errors)) {
@@ -418,7 +424,8 @@ function find_contact_by_id($id) {
         $sql .= "email='" . db_escape($db, $contact['email']) . "', ";
         $sql .= "comments='" . db_escape($db, $contact['comments']) . "', ";
         $sql .= "contact_number='" . db_escape($db, $contact['contact_number']) . "', ";
-        $sql .= "rank_id=" . $rank_id . " "; // Directly use NULL if rank_id is not set
+        $sql .= "favorite=" . (int)$contact['favorite'] . ", "; // Update favorite status
+        $sql .= "rank_id=" . $rank_id; // Directly use NULL if rank_id is not set
 
         // Add the image field only if a new image was uploaded
         if (!empty($contact['image'])) {
@@ -439,7 +446,8 @@ function find_contact_by_id($id) {
         }
     }
 
-    function delete_contact($id) {
+
+function delete_contact($id) {
         global $db;
 
         $sql = "DELETE FROM contact_list ";

--- a/public/contacts/contact-edit.php
+++ b/public/contacts/contact-edit.php
@@ -1,76 +1,66 @@
 <?php
-    require_once('../../private/initialize.php');
+require_once('../../private/initialize.php');
 
-    require_login();
+require_login();
 
-    if(!isset($_GET['id'])) {
-      redirect_to(url_for('/index.php'));
-    }
-    $id = $_GET['id'];
+if (!isset($_GET['id'])) {
+    redirect_to(url_for('/index.php'));
+}
+$id = $_GET['id'];
 
-    if(is_post_request()) {
+if (is_post_request()) {
 
-      // Handle form values sent by new.php
+    $contact = [];
+    $contact['id'] = $id;
+    $contact['first_name'] = $_POST['first_name'] ?? '';
+    $contact['last_name'] = $_POST['last_name'] ?? '';
+    $contact['email'] = $_POST['email'] ?? '';
+    $contact['comments'] = $_POST['comments'] ?? '';
+    $contact['contact_number'] = $_POST['contact_number'] ?? '';
+    $contact['rank_id'] = $_POST['rank_id'] ?? '';
+    $contact['favorite'] = isset($_POST['favorite']) ? 1 : 0; // Add favorite status from checkbox
 
-      $contact = [];
-      $contact['id'] = $id;
-      $contact['first_name'] = $_POST['first_name'] ?? '';
-      $contact['last_name'] = $_POST['last_name'] ?? '';
-      $contact['email'] = $_POST['email'] ?? '';
-      $contact['comments'] = $_POST['comments'] ?? '';
-      $contact['contact_number'] = $_POST['contact_number'] ?? '';
-      $contact['rank_id'] = $_POST['rank_id'] ?? '';
+    // File upload handling
+    if (!empty($_FILES['image']['name'])) {
+        $file_tmp = $_FILES['image']['tmp_name'];
+        $file_ext = strtolower(end(explode('.',$_FILES['image']['name'])));
 
-        // File upload handling
-        if (!empty($_FILES['image']['name'])) {
-            $file_tmp = $_FILES['image']['tmp_name'];
-            $file_ext = strtolower(end(explode('.',$_FILES['image']['name'])));
-
-            $extensions= array("jpeg","jpg","png");
-            if(in_array($file_ext, $extensions) === false){
-                $errors[]="extension not allowed, please choose a JPEG or PNG file.";
-            }
-
-            if(empty($errors)==true){
-                // TODO: Consider a new way to handle file names
-                $new_filename = uniqid('img_', true) . '.' . $file_ext;
-                $file_destination = 'uploads/' . $new_filename;
-                if(move_uploaded_file($file_tmp, $file_destination)) {
-                    $contact['image'] = $new_filename;  // Update array to include image file name
-                } else {
-                    $errors[] = "Failed to move uploaded file.";
-                }
-            }
+        $extensions= array("jpeg","jpg","png");
+        if(in_array($file_ext, $extensions) === false){
+            $errors[]="extension not allowed, please choose a JPEG or PNG file.";
         }
 
-      $result = update_contact($contact);
-      if($result === true) {
-        redirect_to(url_for('/contacts/index.php'));
-      } else {
-        $errors = $result;
-        //var_dump($errors);
-      }
-
-    } else {
-
-      $contact = find_contact_by_id($id);
-
+        if(empty($errors)==true){
+            $new_filename = uniqid('img_', true) . '.' . $file_ext;
+            $file_destination = 'uploads/' . $new_filename;
+            if(move_uploaded_file($file_tmp, $file_destination)) {
+                $contact['image'] = $new_filename;  // Update array to include image file name
+            } else {
+                $errors[] = "Failed to move uploaded file.";
+            }
+        }
     }
 
-    // my original code
-    $title = "Edit Contact";
-    // this is for <title>
+    $result = update_contact($contact);
+    if($result === true) {
+        redirect_to(url_for('/contacts/index.php'));
+    } else {
+        $errors = $result;
+        //var_dump($errors);
+    }
 
-    $page_heading = "Edit the contact";
-    // This is for breadcrumbs if I want a custom title other than the default
+} else {
 
-    $page_subheading = "Test the database functionality";
-    // This is the subheading
+    $contact = find_contact_by_id($id);
 
-    $custom_class = "edit-contact-page";
-    //custom CSS for this page only
+}
 
-    include_once(INCLUDES_PATH . '/site-header.php');
+$title = "Edit Contact";
+$page_heading = "Edit the contact";
+$page_subheading = "Test the database functionality";
+$custom_class = "edit-contact-page";
+
+include_once(INCLUDES_PATH . '/site-header.php');
 
 ?>
 
@@ -91,6 +81,9 @@
             <div class="contact-image">
                 <img src="<?php echo url_for('contacts/uploads/' . $contact['image']); ?>" alt="image" class="mb-4" style="max-width: 200px; display: block; margin: 0 auto;">
             </div>
+
+            <label for="favorite">Favorite:</label>
+            <input type="checkbox" id="favorite" name="favorite" <?php echo ($contact['favorite'] ? 'checked' : ''); ?>><br />
 
             <label for="first_name">First name:</label>
             <input type="text" name="first_name" value="<?php echo h($contact['first_name']); ?>" /><br />
@@ -123,9 +116,11 @@
                 ?>
             </select><br />
 
+            <label for="favorite">Favorite:</label>
+            <input type="checkbox" id="favorite" name="favorite" <?php echo ($contact['favorite'] ? 'checked' : ''); ?>><br />
+
             <label for="image">Upload Image:</label>
             <input type="file" name="image" id="image"><br />
-
 
             <input type="submit" name="submit" value="Edit Contact" id="button" class="btn btn-warning" />
             <a class="btn btn-danger" href="<?php echo url_for('/contacts/contact-remove.php'); ?>">Delete Contact(s)</a>
@@ -135,9 +130,3 @@
 </div>
 
 <?php include_once(INCLUDES_PATH . '/site-footer.php');?>
-
-
-
-
-
-

--- a/public/contacts/contact-show.php
+++ b/public/contacts/contact-show.php
@@ -27,6 +27,8 @@ include_once(INCLUDES_PATH . '/site-header.php');
                 <div class="contact show mb-4">
                     <h1 class="h3">Contact: <?php echo h($contact['first_name']) . " " . h($contact['last_name']); ?></h1>
 
+
+
                     <div class="attributes">
                         <?php
                         if ($contact['image'] == '') {
@@ -35,6 +37,10 @@ include_once(INCLUDES_PATH . '/site-header.php');
                             echo '<div class="contact-image mb-3"><img src="uploads/' . h($contact['image']) . '" alt="Contact image" style="max-width: 200px;"></div>';
                         }
                         ?>
+
+                        <?php if ($contact['favorite']): ?>
+                            <p>Favorited</p>
+                        <?php endif; ?>
 
                         <dl class="mb-2">
                             <dt>First Name</dt>

--- a/public/contacts/index.php
+++ b/public/contacts/index.php
@@ -37,6 +37,7 @@ include_once(INCLUDES_PATH . '/site-header.php');
                 <option value="first_name" <?php echo ($sort == 'first_name') ? 'selected' : ''; ?>>First Name</option>
                 <option value="last_name" <?php echo ($sort == 'last_name') ? 'selected' : ''; ?>>Last Name</option>
                 <option value="email" <?php echo ($sort == 'email') ? 'selected' : ''; ?>>Email</option>
+                <option value="favorite" <?php echo ($sort == 'favorite') ? 'selected' : ''; ?>>Favorite</option>
             </select>
             <button type="submit">Sort</button>
         </form>
@@ -45,15 +46,16 @@ include_once(INCLUDES_PATH . '/site-header.php');
         <p>This uses the `find_all_contacts()` function from the `query_functions.php` file.</p>
         <table class="table table-striped border">
             <thead class="thead-dark">
-                <tr>
-                    <th scope="col"><a href="#" class="sort-header" data-sort="id">ID</a></th>
-                    <th scope="col"><a href="#" class="sort-header" data-sort="first_name">First Name</a></th>
-                    <th scope="col"><a href="#" class="sort-header" data-sort="last_name">Last Name</a></th>
-                    <th scope="col"><a href="#" class="sort-header" data-sort="email">Email</a></th>
-                    <th scope="col">&nbsp;</th>
-                    <th scope="col">&nbsp;</th>
-                    <th scope="col">&nbsp;</th>
-                </tr>
+            <tr>
+                <th scope="col"><a href="#" class="sort-header" data-sort="id">ID</a></th>
+                <th scope="col"><a href="#" class="sort-header" data-sort="first_name">First Name</a></th>
+                <th scope="col"><a href="#" class="sort-header" data-sort="last_name">Last Name</a></th>
+                <th scope="col"><a href="#" class="sort-header" data-sort="email">Email</a></th>
+                <th scope="col"><a href="#" class="sort-header" data-sort="favorite">Favorite</a></th>
+                <th scope="col">&nbsp;</th>
+                <th scope="col">&nbsp;</th>
+                <th scope="col">&nbsp;</th>
+            </tr>
             </thead>
 
             <tbody>
@@ -63,6 +65,7 @@ include_once(INCLUDES_PATH . '/site-header.php');
                     <td><?php echo h($contact['first_name']); ?></td>
                     <td><?php echo h($contact['last_name']); ?></td>
                     <td><?php echo h($contact['email']); ?></td>
+                    <td><?php echo $contact['favorite'] ? 'Yes' : 'No'; ?></td>
                     <td><a class="action btn d-block mx-auto btn-info" href="<?php echo url_for('/contacts/contact-show.php?id=' . h(u($contact['id']))); ?>">View</a></td>
                     <td><a class="action btn d-block mx-auto btn-warning" href="<?php echo url_for('/contacts/contact-edit.php?id=' . h(u($contact['id']))); ?>">Edit</a></td>
                     <td><a class="action btn d-block mx-auto btn-danger" href="<?php echo url_for('/contacts/contact-delete.php?id=' . h(u($contact['id']))); ?>">Delete</a></td>


### PR DESCRIPTION
Modified the sorting logic in the find_all_contacts function to ensure that when sorting by the 'favorite' column, contacts marked as favorites are displayed at the top. This was achieved by applying a DESC order for the 'favorite' sort parameter, while maintaining ASC order for all other valid sorting columns.